### PR TITLE
Updating how Blockers interact with Green Civics to be functional and streamlined

### DIFF
--- a/common/deposits/ethic_rebuild_deposits.txt
+++ b/common/deposits/ethic_rebuild_deposits.txt
@@ -231,7 +231,6 @@ d_mountain_range = {
 			exists = owner
 			owner = {
 				is_regular_empire = yes
-				is_catalytic_empire = no
 				has_valid_civic = civic_eco_warfare
 			}
 		}
@@ -247,43 +246,7 @@ d_mountain_range = {
 		potential = {
 			exists = owner
 			owner = {
-				is_regular_empire = yes
-				is_catalytic_empire = yes
-				has_valid_civic = civic_eco_warfare
-			}
-		}
-		modifier = {
-			planet_housing_add = 100
-			planet_orbital_bombardment_damage = -0.1
-			job_ranger_add = 100
-			job_catalytic_technician_add = 100
-		}
-	}
-
-	# joakim.westergaard: Based on 04_manufacturing_buildings.txt.txt there should be no "is_catalytic_empire = yes" instances for the following three Empire types
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_hive_empire = yes
-				is_catalytic_empire = no
-				has_valid_civic = civic_eco_warfare
-			}
-		}
-		modifier = {
-			planet_housing_add = 100
-			planet_orbital_bombardment_damage = -0.1
-			job_ranger_add = 100
-			job_alloy_drone_add = 100
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_machine_empire = yes
-				is_catalytic_empire = no
+				is_gestalt = yes
 				has_valid_civic = civic_eco_warfare
 			}
 		}
@@ -299,25 +262,7 @@ d_mountain_range = {
 		potential = {
 			exists = owner
 			owner = {
-				is_gestalt = yes
-				is_catalytic_empire = yes
-				has_valid_civic = civic_eco_warfare
-			}
-		}
-		modifier = {
-			planet_housing_add = 100
-			planet_orbital_bombardment_damage = -0.1
-			job_ranger_add = 100
-			job_catalytic_drone_add = 100
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
 				is_regular_empire = yes
-				is_crafter_empire = no
 				has_valid_civic = civic_naturalism
 			}
 		}
@@ -325,22 +270,6 @@ d_mountain_range = {
 			planet_housing_add = 600
 			job_culture_worker_add = 100
 			job_artisan_add = 100
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_regular_empire = yes
-				is_crafter_empire = yes
-				has_valid_civic = civic_naturalism
-			}
-		}
-		modifier = {
-			planet_housing_add = 600
-			job_culture_worker_add = 100
-			job_artificer_add = 100
 		}
 	}
 
@@ -378,7 +307,7 @@ d_mountain_range = {
 		}
 		modifier = {
 			planet_housing_add = 200
-			planet_max_buildings_add = 1
+			planet_max_districts_add = 1
 			job_geoengineer_add = 200
 		}
 	}
@@ -542,7 +471,6 @@ d_active_volcano = {
 			exists = owner
 			owner = {
 				is_regular_empire = yes
-				is_catalytic_empire = no
 				has_valid_civic = civic_eco_warfare
 			}
 		}
@@ -558,43 +486,7 @@ d_active_volcano = {
 		potential = {
 			exists = owner
 			owner = {
-				is_regular_empire = yes
-				is_catalytic_empire = yes
-				has_valid_civic = civic_eco_warfare
-			}
-		}
-		modifier = {
-			planet_housing_add = 100
-			planet_orbital_bombardment_damage = -0.1
-			job_ranger_add = 100
-			job_catalytic_technician_add = 100
-		}
-	}
-
-	# joakim.westergaard: Based on 00_urban_districts.txt there should be no "is_crafter_empire = yes" instances for the following three Empire types
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_hive_empire = yes
-				is_catalytic_empire = no
-				has_valid_civic = civic_eco_warfare
-			}
-		}
-		modifier = {
-			planet_housing_add = 100
-			planet_orbital_bombardment_damage = -0.1
-			job_ranger_add = 100
-			job_alloy_drone_add = 100
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_machine_empire = yes
-				is_catalytic_empire = no
+				is_gestalt = yes
 				has_valid_civic = civic_eco_warfare
 			}
 		}
@@ -610,25 +502,7 @@ d_active_volcano = {
 		potential = {
 			exists = owner
 			owner = {
-				is_gestalt = yes
-				is_catalytic_empire = yes
-				has_valid_civic = civic_eco_warfare
-			}
-		}
-		modifier = {
-			planet_housing_add = 100
-			planet_orbital_bombardment_damage = -0.1
-			job_ranger_add = 100
-			job_catalytic_drone_add = 100
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
 				is_regular_empire = yes
-				is_crafter_empire = no
 				has_valid_civic = civic_naturalism
 			}
 		}
@@ -636,22 +510,6 @@ d_active_volcano = {
 			planet_housing_add = 600
 			job_culture_worker_add = 100
 			job_artisan_add = 100
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_regular_empire = yes
-				is_crafter_empire = yes
-				has_valid_civic = civic_naturalism
-			}
-		}
-		modifier = {
-			planet_housing_add = 600
-			job_culture_worker_add = 100
-			job_artificer_add = 100
 		}
 	}
 
@@ -689,7 +547,7 @@ d_active_volcano = {
 		}
 		modifier = {
 			planet_housing_add = 200
-			planet_max_buildings_add = 1
+			planet_max_districts_add = 1
 			job_geoengineer_add = 200
 		}
 	}
@@ -851,7 +709,7 @@ d_dangerous_wildlife_blocker = {
 			planet_housing_add = 100
 			planet_orbital_bombardment_damage = -0.1
 			job_ranger_add = 100
-			job_duelist_add = 100
+			job_entertainer_add = 100
 		}
 	}
 
@@ -886,7 +744,7 @@ d_dangerous_wildlife_blocker = {
 		}
 		modifier = {
 			planet_housing_add = 200
-			planet_max_buildings_add = 1
+			planet_max_districts_add = 1
 			job_xenobiologist_add = 200
 		}
 	}
@@ -897,29 +755,12 @@ d_dangerous_wildlife_blocker = {
 			owner = {
 				has_civic = civic_environmentalist
 				country_uses_food = yes
-				is_anglers_empire = no
 			}
 		}
 		modifier = {
 			planet_housing_add = 200
 			planet_amenities_add = 500
 			job_farmer_add = 200
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				has_civic = civic_environmentalist
-				country_uses_food = yes
-				is_anglers_empire = yes
-			}
-		}
-		modifier = {
-			planet_housing_add = 200
-			planet_amenities_add = 500
-			job_angler_add = 200
 		}
 	}
 
@@ -1145,29 +986,12 @@ d_dense_jungle = {
 			owner = {
 				has_civic = civic_environmentalist
 				country_uses_food = yes
-				is_anglers_empire = no
 			}
 		}
 		modifier = {
 			planet_housing_add = 100
 			planet_amenities_add = 500
 			job_farmer_add = 100
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				has_civic = civic_environmentalist
-				country_uses_food = yes
-				is_anglers_empire = yes
-			}
-		}
-		modifier = {
-			planet_housing_add = 100
-			planet_amenities_add = 500
-			job_angler_add = 100
 		}
 	}
 
@@ -1374,29 +1198,12 @@ d_toxic_kelp = {
 			owner = {
 				has_civic = civic_environmentalist
 				country_uses_food = yes
-				is_anglers_empire = no
 			}
 		}
 		modifier = {
 			planet_housing_add = 100
 			planet_amenities_add = 500
 			job_farmer_add = 100
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				has_civic = civic_environmentalist
-				country_uses_food = yes
-				is_anglers_empire = yes
-			}
-		}
-		modifier = {
-			planet_housing_add = 100
-			planet_amenities_add = 500
-			job_angler_add = 100
 		}
 	}
 
@@ -1989,29 +1796,12 @@ d_noxious_swamp = {
 			owner = {
 				has_civic = civic_environmentalist
 				country_uses_food = yes
-				is_anglers_empire = no
 			}
 		}
 		modifier = {
 			planet_housing_add = 100
 			planet_amenities_add = 500
 			job_farmer_add = 100
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				has_civic = civic_environmentalist
-				country_uses_food = yes
-				is_anglers_empire = yes
-			}
-		}
-		modifier = {
-			planet_housing_add = 100
-			planet_amenities_add = 500
-			job_angler_add = 100
 		}
 	}
 
@@ -2705,43 +2495,19 @@ d_migrating_forest_reserve = {
 	planet_modifier = {
 		planet_jobs_society_research_produces_mult = 0.2
 	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		modifier = {
-			job_calculator_physicist_add = 100
-			job_calculator_biologist_add = 40
-			job_calculator_engineer_add = 60
-		}
+	inline_script = {
+		script = jobs/physicists_add
+		AMOUNT = 100
 	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		modifier = {
-			job_calculator_physicist_add = 100
-			job_calculator_biologist_add = 40
-			job_calculator_engineer_add = 60
-		}
+	inline_script = {
+		script = jobs/biologists_add
+		AMOUNT = 40
 	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		modifier = {
-			job_calculator_physicist_add = 100
-			job_calculator_biologist_add = 40
-			job_calculator_engineer_add = 60
-		}
+	inline_script = {
+		script = jobs/engineers_add
+		AMOUNT = 60
 	}
-
+	
 	triggered_planet_modifier = {
 		potential = {
 			exists = owner
@@ -2838,40 +2604,17 @@ d_savage_wildlands = {
 		planet_jobs_society_research_produces_mult = 0.1
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_regular_empire = yes }
-		}
-		modifier = {
-			job_physicist_add = 50
-			job_biologist_add = 20
-			job_engineer_add = 30
-		}
+	inline_script = {
+		script = jobs/physicists_add
+		AMOUNT = 50
 	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		modifier = {
-			job_calculator_physicist_add = 50
-			job_calculator_biologist_add = 20
-			job_calculator_engineer_add = 30
-		}
+	inline_script = {
+		script = jobs/biologists_add
+		AMOUNT = 20
 	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_machine_empire = yes }
-		}
-		modifier = {
-			job_calculator_physicist_add = 50
-			job_calculator_biologist_add = 20
-			job_calculator_engineer_add = 30
-		}
+	inline_script = {
+		script = jobs/engineers_add
+		AMOUNT = 30
 	}
 
 	triggered_planet_modifier = {


### PR DESCRIPTION
### Change Notes:

- Removed catalytic variations of foundry jobs from blocker effects - they're under the same job now 
- Removed pearl divers and artificer variations of artisan jobs from blocker effects  - they're under the same job now 
- Changed the +1 max building from ecological engineers under certain blockers to be +1 max district 
- Removed angler variations of farmer jobs from blocker effects - they're under the same job now 
- Unified some checks for hive and machine empires related to foundry jobs from blocker effects - both use job_fabricator and alloy drones are a job swap now 
- Remove Duelist variations of entertainer jobs from blocker effects - they're under the same job now. 
- Streamlined certain rare blockers with vanilla inline scripts for researchers

I'm a little hesitant on the duelist change, because they'll be entertainers now, it's probably for the best. Because while they won't be duelists without changing swap conditions, the vanilla duelist job has been integrated into entertainers and it's probably better to not have to maintain another custom job that won't be compatible with even vanilla modifiers without hard coding.

I think the +1 building max to +1 district max is a fair change - they only appear on big blockers that block 2 districts, like dangerous wildlife and active volcanos, so they just make it so that they're a -1 district blocker instead of a -2