### PR TITLE
Fatal error fix caused by missing tech

### DIFF
--- a/common/armies/EaC_rebuild_assault_armies.txt
+++ b/common/armies/EaC_rebuild_assault_armies.txt
@@ -208,7 +208,7 @@ missile_truck_army = {
 		}
 	}
 
-	prerequisites = { "tech_primitive_space_age_weapon" }
+	prerequisites = { "tech_primitive_space_age_weapons" }
 
 	show_tech_unlock_if = {
 		country_uses_bio_ships = no

--- a/common/armies/primitive_players_armies.txt
+++ b/common/armies/primitive_players_armies.txt
@@ -298,7 +298,7 @@ industrial_missile_truck_army = {
 		owner = { has_technology = tech_assault_armies }	#Primitive Players can't have assault ships until this tech
 		NOT = {
 			owner = { has_technology = tech_missiles_1 }
-			owner = { has_technology = tech_primitive_space_age_weapon }	#'Assault Armies' provide space-fleets, we don't want that until interstellar war
+			owner = { has_technology = tech_primitive_space_age_weapons }	#'Assault Armies' provide space-fleets, we don't want that until interstellar war
 		}
 	}
 
@@ -351,7 +351,7 @@ atomic_missile_truck_army = {
 		always = no #For balance reasons this is disabled
 		owner = { has_technology = tech_assault_armies }	#Primitive Players can't have assault ships until this tech
 		NOT = {
-			owner = { has_technology = tech_primitive_space_age_weapon }	#'Assault Armies' provide space-fleets, we don't want that until interstellar war
+			owner = { has_technology = tech_primitive_space_age_weapons }	#'Assault Armies' provide space-fleets, we don't want that until interstellar war
 		}
 	}
 


### PR DESCRIPTION
Stellaris 4.4/Nomads introduced a fatal error when referencing to ` tech_primitive_space_age_weapon`. This tech now only exists in plural form `tech_primitive_space_age_weapons`, changed 3 references to the plural form. 
These small edits solve the fatal error, but does not otherwise bring any other Nomads compatability.